### PR TITLE
Clear hashVars after every iteration

### DIFF
--- a/src/approxmc.cpp
+++ b/src/approxmc.cpp
@@ -426,6 +426,7 @@ bool AppMC::count(SATCount& count)
             hashPrev = swapVar;
         }
         assumps.clear();
+        hashVars.clear();   
         hashCount = mPrev;
     }
     if (numHashList.size() == 0) {


### PR DESCRIPTION
Corrected a bug that prevented  random constraint generation after every iteration .