### PR TITLE
Setting delta and epsilon read from command line; Fixing set_detach_xors

### DIFF
--- a/src/approxmc.cpp
+++ b/src/approxmc.cpp
@@ -146,6 +146,7 @@ DLL_PUBLIC void AppMC::set_var_elim_ratio(double var_elim_ratio)
 DLL_PUBLIC void AppMC::set_detach_xors(uint32_t detach_xors)
 {
     data->conf.cms_detach_xor = detach_xors;
+    data->counter.solver->set_xor_detach(data->conf.cms_detach_xor);
 }
 
 DLL_PUBLIC void AppMC::set_reuse_models(uint32_t reuse_models)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -361,6 +361,8 @@ int main(int argc, char** argv)
         appmc->set_detach_warning();
     }
     appmc->set_seed(seed);
+    appmc->set_epsilon(epsilon);
+    appmc->set_delta(delta);
 
     //Improvement options
     appmc->set_detach_xors(detach_xors);


### PR DESCRIPTION
Delta and epsilon specified in command line aren't used now. Add the
function call to set the specified value.

The function set_detach_xors doesn't pass the setting of detach_xors to
the underlying SAT solver. Add the function call to pass the setting.
