### PR TITLE
Fixing the bug when start_iter is greater than final hashCount

### DIFF
--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -532,7 +532,7 @@ void Counter::one_measurement_count(
     int64_t upperFib = total_max_xors;
 
     int64_t hashCount = mPrev;
-    int64_t hashPrev = hashCount;
+    int64_t hashPrev = 0;
     while (numExplored < total_max_xors) {
         uint64_t cur_hash_count = hashCount;
         const vector<Lit> assumps = set_num_hashes(hashCount, hm.hashes, sparse_data);


### PR DESCRIPTION
If specify a start_iter greater than final hashCount, the program will
abort now. The normal behaviour should be to continue searching from
the given start_iter. It's caused by the mistaken initial value of
hashPrev in searching. Fix now.