### PR TITLE
define default value for hashCount == -1

### DIFF
--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -523,6 +523,8 @@ void Counter::one_measurement_count(
     //number of solutions.
     //if it's not set, we have no clue.
     map<uint64_t,bool> threshold_sols;
+    //When hashCount == 0, the previous hashCount (i.e. -1) should have threshold solutions by default.
+    threshold_sols[-1] = 1;
 
     HashesModels hm;
 


### PR DESCRIPTION
Suppose hashCount == k in the procedure of LogSATSearch, we claim to find an answer if we have found threshold solutions when hashCount == k-1 and less than threshold solutions when hashCount == k. However, when hashCount == 0, the status of hashCount == -1 is undefined, resulting in no answer returned and finally outputting UNSAT.

In a normal running when approxmc starts from 0 xor, the case will be avoided, because we have a particular procedure to check if the CNF has threshold solutions as the initial measurement. Therefore, the program goes into LogSATSearch only if there are more than threshold solutions which guarantees the program won't reach the state that query if there are threshold solutions when hashCount == -1 after finding less than threshold solutions when hashCount == 0.

However, when running approxmc starting from greater than 0 xors, it'll jump over the initial measurement which would only run when starting hashCount == 0. Therefore, the guarantee before disappears, and the program will run into the state to query the status of hashCount == -1 which is undefined, however. Finally, it ends up with the error:  **ApproxMC::SolCount Counter::count(): Assertion `numHashList.size() > 0 && "UNSAT should not be possible"' failed.**

You can reproduce the error by the following case: [demo.txt](https://github.com/meelgroup/approxmc/files/5581557/demo.txt) when specifying flag: --start t (t >0). Actually, you can reproduce it with any case of less than threshold solutions and starting from greater than 0 xors.

Therefore, propose to define the default value for hashCount == -1 to fix it. Claim that there are always threshold solutions when hashCount == -1.
