### PR TITLE
Changed test to match python API and update README to match output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ count = c.count()
 print("Approximate count is: %d*2**%d" % (count[0], count[1]))
 ```
 
-The above will print that `Approximate count is: 88*2**13`. Since the largest variable in the clauses was 20, the system contained 2**20 (i.e. 1048576) potential models. However, some of these models were prohibited by the two clauses, and so only approximately 88*2**13 (i.e. 720896) models remained.
+The above will print that `Approximate count is: 11*2**16`. Since the largest variable in the clauses was 20, the system contained 2**20 (i.e. 1048576) potential models. However, some of these models were prohibited by the two clauses, and so only approximately 11*2**16 (i.e. 720896) models remained.
 
 If you want to count over a projection set, you need to call `count(projection_set)`, for example:
 
@@ -45,7 +45,7 @@ count = c.count(range(1,10))
 print("Approximate count is: %d*2**%d" % (count[0], count[1]))
 ```
 
-This now prints `Approximate count is: 56*2**3`, which corresponds to the approximate count of models, projected over variables 1..10.
+This now prints `Approximate count is: 7*2**6`, which corresponds to the approximate count of models, projected over variables 1..10.
 
 ## How to Build a Binary
 To build on Linux, you will need the following:

--- a/python/tests/test_pyapproxmc.py
+++ b/python/tests/test_pyapproxmc.py
@@ -6,12 +6,12 @@ def minimal_test():
     assert counter.count() == (512, 90)
 
 def sampling_set_test():
-    counter = Counter(seed=2157, epsilon=0.8, delta=0.2, sampling_set=list(range(1,50)))
+    counter = Counter(seed=2157, epsilon=0.8, delta=0.2)
     counter.add_clause(range(1,100))
-    assert counter.count() == (64, 43)
+    assert counter.count(list(range(1,50))) == (64, 43)
 
 def real_example_test():
-    counter = Counter(seed=120, epsilon=0.8, delta=0.2, sampling_set=list(range(1,21)))
+    counter = Counter(seed=120, epsilon=0.8, delta=0.2)
 
     with open("test_1.cnf") as test_cnf:
         # Pop sampling set and metadata lines
@@ -22,7 +22,7 @@ def real_example_test():
             literals = [int(i) for i in line.split()[:-1]]
             counter.add_clause(literals)
 
-    assert counter.count() == (64,14)
+    assert counter.count(list(range(1,21))) == (64,14)
 
 if __name__ == '__main__':
     minimal_test()


### PR DESCRIPTION
Hi,

Thanks for the tool ! Looks like the python test was using an older API. I updated it to pass the projection set to the `count` function and updated the README to match the output, which is represented differently (but numerically the same).