### PR TITLE
Fix adding many clauses

### DIFF
--- a/python/src/pyapproxmc.cpp
+++ b/python/src/pyapproxmc.cpp
@@ -241,10 +241,10 @@ static int _add_clauses_from_array(Counter *self, const size_t array_length, con
             lits.push_back(CMSat::Lit(var, sign));
         }
         if (!lits.empty()) {
-            if (max_var >= (long int)self->appmc->nVars()) {
-                self->appmc->new_vars(max_var-(long int)self->appmc->nVars()+1);
+            if (max_var >= (long int)self->arjun->nVars()) {
+                self->arjun->new_vars(max_var-(long int)self->arjun->nVars()+1);
             }
-            self->appmc->add_clause(lits);
+            self->arjun->add_clause(lits);
         }
     }
     return 1;

--- a/python/tests/test_pyapproxmc.py
+++ b/python/tests/test_pyapproxmc.py
@@ -1,16 +1,23 @@
+import sys
+
+import pytest
+
 from pyapproxmc import Counter
 
-def minimal_test():
+def test_minimal():
     counter = Counter(seed=2157, epsilon=0.8, delta=0.2)
     counter.add_clause(list(range(1,100)))
-    assert counter.count() == (512, 90)
 
-def sampling_set_test():
+    significand, exponent = counter.count()
+    print(f'count: {significand} * 2**{exponent}')
+    assert significand * 2**exponent == 512 * 2**90
+
+def test_sampling_set():
     counter = Counter(seed=2157, epsilon=0.8, delta=0.2)
     counter.add_clause(range(1,100))
     assert counter.count(list(range(1,50))) == (64, 43)
 
-def real_example_test():
+def test_real_example():
     counter = Counter(seed=120, epsilon=0.8, delta=0.2)
 
     with open("test_1.cnf") as test_cnf:
@@ -24,7 +31,6 @@ def real_example_test():
 
     assert counter.count(list(range(1,21))) == (64,14)
 
+
 if __name__ == '__main__':
-    minimal_test()
-    sampling_set_test()
-    real_example_test()
+    pytest.main([__file__, '-v'] + sys.argv[1:])

--- a/python/tests/test_pyapproxmc.py
+++ b/python/tests/test_pyapproxmc.py
@@ -1,8 +1,11 @@
+#!/usr/bin/env python3
 import sys
+from array import array
 
 import pytest
 
 from pyapproxmc import Counter
+
 
 def test_minimal():
     counter = Counter(seed=2157, epsilon=0.8, delta=0.2)
@@ -12,10 +15,12 @@ def test_minimal():
     print(f'count: {significand} * 2**{exponent}')
     assert significand * 2**exponent == 512 * 2**90
 
+
 def test_sampling_set():
     counter = Counter(seed=2157, epsilon=0.8, delta=0.2)
     counter.add_clause(range(1,100))
     assert counter.count(list(range(1,50))) == (64, 43)
+
 
 def test_real_example():
     counter = Counter(seed=120, epsilon=0.8, delta=0.2)
@@ -30,6 +35,35 @@ def test_real_example():
             counter.add_clause(literals)
 
     assert counter.count(list(range(1,21))) == (64,14)
+
+
+def test_add_clauses_minimal():
+    counter = Counter(seed=2157, epsilon=0.8, delta=0.2)
+    clauses = array('i', list(range(1,100)) + [0])
+    counter.add_clauses(clauses)
+
+    significand, exponent = counter.count()
+    print(f'count: {significand} * 2**{exponent}')
+    assert significand * 2**exponent == 512 * 2**90
+
+
+def test_add_clauses_real_example():
+    counter = Counter(seed=120, epsilon=0.8, delta=0.2)
+    clauses = []
+
+    with open("test_1.cnf") as test_cnf:
+        # Pop sampling set and metadata lines
+        lines = test_cnf.readlines()[2:]
+
+        # Add clauses to counter
+        for line in lines:
+            clause = [int(i) for i in line.split()]
+            clauses += clause
+
+    counter.add_clauses(array('i', clauses))
+    significand, exponent = counter.count(list(range(1,21)))
+    print(f'count: {significand} * 2**{exponent}')
+    assert significand * 2**exponent == 64 * 2**14
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The support for adding many clauses using the `add_clauses` method in the Python bindings did not work since the clauses where added to the `self->appmc` object instead of the `self->arjun` object. (The code for `add_clause` only interacts with the `self->arjun` object.) This pull request fixes that. 

Also in the process of debugging the issue, I created two new test cases and converted the Python test suite to use pytest which makes it a bit nicer in my opinion.

With the test cases I noticed that the minimal test case was failing on my machine because ApproxMC returned `64 * 2**93` instead of `512 * 2**90`. This could be because I'm running on an ARM machine. Anyway, I adapted the test case to compare the final total.