### PR TITLE
improve error reporting for Python bindings

### DIFF
--- a/python/src/pyapproxmc.cpp
+++ b/python/src/pyapproxmc.cpp
@@ -160,7 +160,7 @@ static int parse_clause(Counter *self, PyObject *clause, std::vector<CMSat::Lit>
         if (allow_more_vars)
             self->arjun->new_vars(max_var-(long int)self->arjun->nVars()+1);
         else {
-            PyErr_SetString(PyExc_SystemError,
+            PyErr_SetString(PyExc_ValueError,
                     "ERROR: Sampling vars contain variables that are not in the original clauses!");
             return 0;
         }
@@ -413,8 +413,7 @@ Approximately count the number of solutions to the formula. It can only be calle
 static PyObject* count(Counter *self, PyObject *args, PyObject *kwds)
 {
     if (self->count_called) {
-        PyErr_SetString(PyExc_SystemError,
-                        "ERROR: Sampling vars contain variables that are not in the original clauses!");
+        PyErr_SetString(PyExc_ValueError, "ERROR: Counter.count() may only be called once!");
         return NULL;
     } else {
         self->count_called = true;
@@ -436,7 +435,7 @@ static PyObject* count(Counter *self, PyObject *args, PyObject *kwds)
         }
         for(const auto& l: sampling_lits) {
             if (l.var() > self->arjun->nVars()) {
-                PyErr_SetString(PyExc_SystemError,
+                PyErr_SetString(PyExc_ValueError,
                         "ERROR: Sampling vars contain variables that are not in the original clauses!");
                 return NULL;
             }


### PR DESCRIPTION
This pull request improves the exceptions thrown by the Python bindings. (I'm creating a separate PR, because this changes the API in a minor way).

According to the Python Documentation the `SystemError` exception should only be thrown if the interpreter encounters an internal error. I think `ValueError` works better here. Also, I changed a message that was probably copy-pasted wrong.