### PR TITLE
Run tests in ci

### DIFF
--- a/.github/workflows/newpython.yml
+++ b/.github/workflows/newpython.yml
@@ -35,6 +35,8 @@ jobs:
         # to supply options, put them in 'env', like:
         env:
           CIBW_BEFORE_ALL_LINUX: yum install -y boost-devel zlib-devel
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: "pytest --color=yes -v {project}/python/tests/test_pyapproxmc.py"
           CIBW_SKIP: "*musl*"
           CIBW_ARCHS: "auto64"
 

--- a/python/tests/test_pyapproxmc.py
+++ b/python/tests/test_pyapproxmc.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 from array import array
+from pathlib import Path
 
 import pytest
 
@@ -25,7 +26,8 @@ def test_sampling_set():
 def test_real_example():
     counter = Counter(seed=120, epsilon=0.8, delta=0.2)
 
-    with open("test_1.cnf") as test_cnf:
+    cnf_file = Path(__file__).parent / "test_1.cnf"
+    with open(cnf_file) as test_cnf:
         # Pop sampling set and metadata lines
         lines = test_cnf.readlines()[2:]
 
@@ -51,7 +53,8 @@ def test_add_clauses_real_example():
     counter = Counter(seed=120, epsilon=0.8, delta=0.2)
     clauses = []
 
-    with open("test_1.cnf") as test_cnf:
+    cnf_file = Path(__file__).parent / "test_1.cnf"
+    with open((cnf_file)) as test_cnf:
         # Pop sampling set and metadata lines
         lines = test_cnf.readlines()[2:]
 
@@ -67,4 +70,5 @@ def test_add_clauses_real_example():
 
 
 if __name__ == '__main__':
-    pytest.main([__file__, '-v'] + sys.argv[1:])
+    ret = pytest.main([__file__, '-v'] + sys.argv[1:])
+    raise SystemExit(ret)


### PR DESCRIPTION
This runs the Python test cases in the `newpython.yml` GitHub action. There's also a `python-package-build.yml` - I guess this one is being phased out?

Also, I changed the path of the CNF file to be relative to the `test_pyapproxmc.py` file, so the tests can be run form a different working directory.