### PR TITLE
README.md install tools at same dir level

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,23 +78,22 @@ cd cryptominisat
 mkdir build && cd build
 cmake ..
 make
-cd ..
+cd ../..
 
 git clone https://github.com/meelgroup/sbva
 cd sbva
 mkdir build && cd build
 cmake ..
 make
-cd ..
+cd ../..
 
 git clone https://github.com/meelgroup/arjun
 cd arjun
 mkdir build && cd build
 cmake ..
 make
-cd ..
-
 cd ../..
+
 git clone https://github.com/meelgroup/approxmc
 cd approxmc
 mkdir build && cd build


### PR DESCRIPTION
The current instructions gives a slightly awkward nested folder structure (CMS/sbva/arjun) when copy-pasted directly which I guess (?) is unintended.