### PR TITLE
Release ApproxMC7

### DIFF
--- a/src/appmcconfig.h
+++ b/src/appmcconfig.h
@@ -54,6 +54,7 @@ public:
     int dump_intermediary_cnf = 0;
     int debug = 0;
     int force_sol_extension = false;
+    double appmc7_eps_cutoff = 5;
 
     std::vector<uint32_t> sampl_vars;
     bool sampl_vars_set = false;

--- a/src/counter.cpp
+++ b/src/counter.cpp
@@ -389,6 +389,15 @@ void Counter::set_up_probs_threshold_measurements(
         p_U = 0.044;
     }
 
+    // ApproxMC7
+    if (conf.epsilon >= conf.appmc7_eps_cutoff) {
+        threshold = 0;
+        beta = (1 + sqrt( 1 + 2*(1+conf.epsilon)*(1+conf.epsilon) ))/2;
+        alpha = beta - 1;
+        p_L = 1 / (1 + alpha);
+        p_U = 1 / beta;
+    }
+
     for (measurements = 1; ; measurements+=2) {
        if (calc_error_bound(measurements, p_L) + calc_error_bound(measurements, p_U) <= conf.delta) {
            break;
@@ -421,8 +430,12 @@ ApproxMC::SolCount Counter::count()
     //for Probabilistic Inference: From Linear to Logarithmic SAT Calls"
     //https://www.ijcai.org/Proceedings/16/Papers/503.pdf
     for (uint32_t j = 0; j < measurements; j++) {
-        one_measurement_count(prev_measure, j, sparse_data, &hm);
-        if (prev_measure == 0) {
+        if (conf.epsilon < conf.appmc7_eps_cutoff) {
+            one_measurement_count(prev_measure, j, sparse_data, &hm);
+        } else {
+            appmc7_one_measurement_count(prev_measure, j, sparse_data, &hm);
+        }
+        if (prev_measure == 0 && (conf.epsilon < conf.appmc7_eps_cutoff || num_count_list.back() == 0)) {
             // Exact count, no need to measure multiple times.
             verb_print(1, "[appmc] Counted without XORs, i.e. we got exact count");
             break;
@@ -444,7 +457,9 @@ ApproxMC::SolCount Counter::calc_est_count()
     if (num_hash_list[0] > 0) {
         double pivot = 9.84*(1.0+(1.0/conf.epsilon))*(1.0+(1.0/conf.epsilon));
 	    for (auto cnt_it = num_count_list.begin(); cnt_it != num_count_list.end(); cnt_it++) {
-            if (conf.epsilon < sqrt(2)-1) {
+            if (conf.epsilon >= conf.appmc7_eps_cutoff) {
+                *cnt_it *= sqrt(2*alpha/beta);
+            } else if (conf.epsilon < sqrt(2)-1) {
 	            if (*cnt_it < sqrt(1+2*conf.epsilon)/2 * pivot) {
 	    	        *cnt_it = sqrt(1+2*conf.epsilon)/2 * pivot;
 	            }
@@ -632,6 +647,140 @@ void Counter::one_measurement_count(
         hash_prev = cur_hash_cnt;
     }
 }
+
+//See Algorithm 4 in paper "Towards Real-Time Approximate Counting"
+//https://ojs.aaai.org/index.php/AAAI/article/view/33231
+void Counter::appmc7_one_measurement_count(
+    int64_t& prev_measure,
+    const uint32_t iter,
+    SparseData sparse_data,
+    HashesModels* hm)
+{
+    if (conf.sampl_vars.empty()) {
+        auto ret = solver->solve();
+        assert(ret != l_Undef);
+        num_hash_list.push_back(0);
+        num_count_list.push_back(ret == l_True ? 1 : 0);
+        return;
+    }
+
+    //Tells whether a solution is found at hash number N
+    //sols_for_hash[N] tells whether a solution is found when N hashes were added
+    map<uint64_t,int64_t> sols_for_hash;
+
+    //threshold_sols[hash_num]==1 tells us that at hash_num number of hashes
+    //a solution was found
+    //threshold_sols[hash_num]==0 tells that no solution was found.
+    map<uint64_t,bool> threshold_sols;
+    int64_t total_max_xors = conf.sampl_vars.size();
+    int64_t num_explored = 0;
+    int64_t lower_fib = 0;
+    int64_t upper_fib = total_max_xors+1;
+    threshold_sols[lower_fib] = 1;
+    sols_for_hash[lower_fib] = 1;
+    threshold_sols[upper_fib] = 0;
+    sols_for_hash[upper_fib] = 0;
+
+    int64_t hash_cnt = prev_measure;
+    int64_t hash_prev = hash_cnt;
+
+    //We are doing a galloping search here (see our paper for more details).
+    //lower_fib is referred to as loIndex and upper_fib is referred to as hiIndex
+    //The key idea is that we first do an exponential search and then do binary search
+    //This is implemented by using two sentinels: lower_fib and upper_fib. The correct answer
+    // is always between lower_fib and upper_fib. We do exponential search until upper_fib < lower_fib*2
+    // Once upper_fib < lower_fib*2; we do a binary search.
+    while (num_explored < total_max_xors) {
+        uint64_t cur_hash_cnt = hash_cnt;
+        const vector<Lit> assumps = set_num_hashes(hash_cnt, hm->hashes, sparse_data);
+
+        verb_print(1, "[appmc] "
+            "[ " << std::setw(7) << std::setprecision(2) << std::fixed << (cpu_time()-start_time) << " ]"
+            << " round: " << std::setw(2) << iter
+            << " hashes: " << std::setw(6) << hash_cnt);
+        SolNum sols = bounded_sol_count(
+            1, //max no. solutions
+            &assumps, //assumptions to use
+            hash_cnt,
+            iter,
+            hm
+        );
+        const uint64_t num_sols = std::min<uint64_t>(sols.solutions, 1);
+        assert(num_sols <= 1);
+        if (num_sols < 1) {
+            num_explored = lower_fib + total_max_xors - hash_cnt;
+
+            //one less hash count had threshold solutions
+            //this one has less than threshold
+            //so this is the real deal!
+            if (hash_cnt == 0) {
+                num_hash_list.push_back(0);
+                num_count_list.push_back(0);
+                prev_measure = 0;
+                return;
+            }
+            if (threshold_sols.find(hash_cnt-1) != threshold_sols.end()
+                    && threshold_sols[hash_cnt-1] == 1) {
+                num_hash_list.push_back(hash_cnt-1);
+                num_count_list.push_back(1);
+                prev_measure = hash_cnt-1;
+                return;
+            }
+
+            threshold_sols[hash_cnt] = 0;
+            sols_for_hash[hash_cnt] = 0;
+            if (iter > 0 &&
+                std::abs(hash_cnt - prev_measure) <= 2
+            ) {
+                //Doing linear, this is a re-count
+                upper_fib = hash_cnt;
+                hash_cnt--;
+            } else {
+                if (hash_prev > hash_cnt) hash_prev = 0;
+                upper_fib = hash_cnt;
+                if (hash_prev > lower_fib) lower_fib = hash_prev;
+                hash_cnt = (upper_fib+lower_fib)/2;
+            }
+        } else {
+            assert(num_sols == 1);
+            num_explored = hash_cnt + total_max_xors - upper_fib;
+
+            //success record for +1 hashcount exists and is 0
+            //so one-above hashcount was below threshold, this is above
+            //we have a winner -- the one above!
+            if (threshold_sols.find(hash_cnt+1) != threshold_sols.end()
+                && threshold_sols[hash_cnt+1] == 0
+            ) {
+                num_hash_list.push_back(hash_cnt);
+                num_count_list.push_back(1);
+                prev_measure = hash_cnt;
+                return;
+            }
+
+            threshold_sols[hash_cnt] = 1;
+            sols_for_hash[hash_cnt] = 1;
+            if (iter > 0
+                && std::abs(hash_cnt - prev_measure) < 2
+            ) {
+                //Doing linear, this is a re-count
+                lower_fib = hash_cnt;
+                hash_cnt++;
+            } else if (lower_fib + (hash_cnt-lower_fib)*2 >= upper_fib-1) {
+
+                // Whenever the above condition is satisfied, we are in binary search mode
+                lower_fib = hash_cnt;
+                hash_cnt = (lower_fib+upper_fib)/2;
+            } else {
+                // We are in exponential search mode.
+                const auto old_hash_cnt = hash_cnt;
+                hash_cnt = lower_fib + (hash_cnt-lower_fib)*2;
+                if (old_hash_cnt == hash_cnt) hash_cnt++;
+            }
+        }
+        hash_prev = cur_hash_cnt;
+    }
+}
+
 bool Counter::gen_rhs()
 {
     std::uniform_int_distribution<uint32_t> dist{0, 1};

--- a/src/counter.h
+++ b/src/counter.h
@@ -139,6 +139,12 @@ private:
         SparseData sparse_data,
         HashesModels* hm
     );
+    void appmc7_one_measurement_count(
+        int64_t& prev_measure,
+        const unsigned iter,
+        SparseData sparse_data,
+        HashesModels* hm
+    );
     void call_after_parse();
     void ban_one(const uint32_t act_var, const vector<lbool>& model);
     void check_model(
@@ -176,6 +182,8 @@ private:
     uint32_t cnf_dump_no = 0;
     vector<vector<Lit>> cls_in_solver; // needed for accurate dumping
     vector<pair<vector<Lit>, bool>> xors_in_solver; // needed for accurate dumping
+    double alpha;
+    double beta;
 
     int argc;
     char** argv;


### PR DESCRIPTION
Upgrade ApproxMC6 to ApproxMC7 following our recent work: 

Towards Real-Time Approximate Counting
Yash Pote ⓡ Kuldeep S. Meel ⓡ Jiong Yang
Annual AAAI Conference on Artificial Intelligence (AAAI 2025)
ⓡ random order

ApproxMC7 enables the use of a single SAT call to check the cell size under the current approximation scheme, significantly reducing the total number of SAT calls while maintaining the same guarantees as ApproxMC6 in the constant-factor regime. 

This commit enables ApproMC7 when epsilon >= 5 and falls back to ApproxMC6 otherwise. While ApproxMC7 is theoretically sound for epsilon > 1, our current experiments indicate that it consistently outperforms ApproxMC6 when epsilon > 5. Hence, epsilon > 5 serves as a conservative threshold based on current empirical evidence. We plan to relax this threshold once more fine-grained experiments are conducted.